### PR TITLE
Update output if subnet group is not created

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -40,12 +40,12 @@ output "engine_version_actual" {
 
 output "subnet_group_name" {
   description = "The Name of the ElastiCache Subnet Group."
-  value       = aws_elasticache_subnet_group.this[0].name
+  value       = try(aws_elasticache_subnet_group.this[0].name, var.subnet_group_name)
 }
 
 output "subnet_group_subnet_ids" {
   description = "The Subnet IDs of the ElastiCache Subnet Group."
-  value       = aws_elasticache_subnet_group.this[0].subnet_ids
+  value       = try(aws_elasticache_subnet_group.this[0].subnet_ids, var.subnets)
 }
 
 output "parameter_group_arn" {


### PR DESCRIPTION
If the subnet group is provided, it is throwing the error. 
<img width="813" alt="image" src="https://user-images.githubusercontent.com/46669067/176411506-6b7c90b9-aa2b-474a-b3fe-5a6d9f68399b.png">
