### PR TITLE
Update default variables and behaviour

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17
+    rev: v0.1.22
     hooks:
       - id: terraform-fmt
       - id: terraform-validate
@@ -12,17 +12,19 @@ repos:
       - id: shellcheck
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0
+    rev: v1.81.0
     hooks:
       - id: terraform_docs
         args:
-          - "--args=--lockfile=false"
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--add-to-existing-file=true
+          - --hook-config=--recursive=true
       - id: terraform_tfsec
         args:
           - --args=--exclude-downloaded-modules
       - id: checkov
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       # Git style
       - id: check-added-large-files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Terraform Modules Template
-
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
@@ -12,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.18.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.5.0 |
 
 ## Modules
 
@@ -40,10 +38,10 @@ No modules.
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Cluster ID | `string` | `null` | no |
 | <a name="input_cluster_mode_enabled"></a> [cluster\_mode\_enabled](#input\_cluster\_mode\_enabled) | Set to false to diable cluster module | `bool` | `false` | no |
 | <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Cluster size | `number` | `1` | no |
-| <a name="input_create_elasticache_subnet_group"></a> [create\_elasticache\_subnet\_group](#input\_create\_elasticache\_subnet\_group) | Create Elasticache Subnet Group | `bool` | `false` | no |
-| <a name="input_elasticache_parameter_group_family"></a> [elasticache\_parameter\_group\_family](#input\_elasticache\_parameter\_group\_family) | ElastiCache parameter group family | `string` | `"memcached1.6"` | no |
+| <a name="input_create_elasticache_subnet_group"></a> [create\_elasticache\_subnet\_group](#input\_create\_elasticache\_subnet\_group) | Create Elasticache Subnet Group | `bool` | `true` | no |
+| <a name="input_elasticache_parameter_group_family"></a> [elasticache\_parameter\_group\_family](#input\_elasticache\_parameter\_group\_family) | ElastiCache parameter group family | `string` | `"redis7"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Memcached engine version. For more info, see https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions.html | `string` | `"1.6.6"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Redis engine version. https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html | `string` | `"redis7.0"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Elastic cache instance type | `string` | `"cache.t2.micro"` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true` | `string` | `null` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | Maintenance window | `string` | `"wed:03:00-wed:04:00"` | no |
@@ -80,4 +78,4 @@ No modules.
 | <a name="output_reader_endpoint_address"></a> [reader\_endpoint\_address](#output\_reader\_endpoint\_address) | The address of the endpoint for the reader node in the replication group, if the cluster mode is disabled |
 | <a name="output_subnet_group_name"></a> [subnet\_group\_name](#output\_subnet\_group\_name) | The Name of the ElastiCache Subnet Group. |
 | <a name="output_subnet_group_subnet_ids"></a> [subnet\_group\_subnet\_ids](#output\_subnet\_group\_subnet\_ids) | The Subnet IDs of the ElastiCache Subnet Group. |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_elasticache_parameter_group" "this" {
 resource "aws_elasticache_subnet_group" "this" {
   count = var.enabled && var.create_elasticache_subnet_group ? 1 : 0
 
-  name       = var.subnet_group_name
+  name       = format("%s-subnet-group", var.name)
   subnet_ids = var.subnets
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,9 +53,9 @@ variable "instance_type" {
 }
 
 variable "engine_version" {
-  description = "Memcached engine version. For more info, see https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions.html"
+  description = "Redis engine version. https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html"
   type        = string
-  default     = "1.6.6"
+  default     = "redis7.0"
 }
 
 variable "alarm_cpu_threshold_percent" {

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "subnet_group_name" {
 variable "elasticache_parameter_group_family" {
   description = "ElastiCache parameter group family"
   type        = string
-  default     = "memcached1.6"
+  default     = "redis7"
 }
 
 variable "replication_group_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -142,7 +142,7 @@ variable "cluster_id" {
 variable "create_elasticache_subnet_group" {
   description = "Create Elasticache Subnet Group"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "preferred_cache_cluster_azs" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "instance_type" {
 variable "engine_version" {
   description = "Redis engine version. https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html"
   type        = string
-  default     = "redis7.0"
+  default     = "7.0"
 }
 
 variable "alarm_cpu_threshold_percent" {


### PR DESCRIPTION
When trying to use this module to provision a redis cache, I found some of the defaults confusing. For example, the module is hardcoded to provision redis, but variable defaults are set to memcached parameters. This PR attempts to improve on the sensible defaults.