### PR TITLE
Add elasticache redis serverless support with awscc resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.67.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.5.0 |
+| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 0.67.0 |
 
 ## Modules
 
@@ -22,9 +24,13 @@ No modules.
 |------|------|
 | [aws_cloudwatch_metric_alarm.cache_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.cache_memory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cache_serverless_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cache_serverless_ecpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cache_serverless_throttled_commands](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_elasticache_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_parameter_group) | resource |
 | [aws_elasticache_replication_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
+| [awscc_elasticache_serverless_cache.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/elasticache_serverless_cache) | resource |
 
 ## Inputs
 
@@ -32,6 +38,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | The list of actions to execute when this alarm transitions into an ALARM state from any other state. | `list(string)` | `[]` | no |
 | <a name="input_alarm_cpu_threshold_percent"></a> [alarm\_cpu\_threshold\_percent](#input\_alarm\_cpu\_threshold\_percent) | CPU threshold alarm level | `number` | `75` | no |
+| <a name="input_alarm_data_threshold_percent"></a> [alarm\_data\_threshold\_percent](#input\_alarm\_data\_threshold\_percent) | Data threshold alarm level for elasticache serverless | `number` | `75` | no |
+| <a name="input_alarm_ecpu_threshold_percent"></a> [alarm\_ecpu\_threshold\_percent](#input\_alarm\_ecpu\_threshold\_percent) | ECPU threshold alarm level for elasticache serverless | `number` | `75` | no |
 | <a name="input_alarm_memory_threshold_bytes"></a> [alarm\_memory\_threshold\_bytes](#input\_alarm\_memory\_threshold\_bytes) | Alarm memory threshold bytes | `number` | `10000000` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `true` | no |
 | <a name="input_auth_token"></a> [auth\_token](#input\_auth\_token) | Password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true` | `string` | `null` | no |
@@ -39,17 +47,20 @@ No modules.
 | <a name="input_cluster_mode_enabled"></a> [cluster\_mode\_enabled](#input\_cluster\_mode\_enabled) | Set to false to diable cluster module | `bool` | `false` | no |
 | <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Cluster size | `number` | `1` | no |
 | <a name="input_create_elasticache_subnet_group"></a> [create\_elasticache\_subnet\_group](#input\_create\_elasticache\_subnet\_group) | Create Elasticache Subnet Group | `bool` | `true` | no |
+| <a name="input_daily_snapshot_time"></a> [daily\_snapshot\_time](#input\_daily\_snapshot\_time) | The daily time range (in UTC) during which the service takes automatic snapshot of the Serverless Cache | `string` | `"18:00"` | no |
 | <a name="input_elasticache_parameter_group_family"></a> [elasticache\_parameter\_group\_family](#input\_elasticache\_parameter\_group\_family) | ElastiCache parameter group family | `string` | `"redis7"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Redis engine version. https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html | `string` | `"redis7.0"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Redis engine version. https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html | `string` | `"7.0"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Elastic cache instance type | `string` | `"cache.t2.micro"` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true` | `string` | `null` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | Maintenance window | `string` | `"wed:03:00-wed:04:00"` | no |
+| <a name="input_max_data_storage"></a> [max\_data\_storage](#input\_max\_data\_storage) | The maximun cached data capacity of the Serverless Cache in GB | `number` | `10` | no |
+| <a name="input_max_ecpu_per_second"></a> [max\_ecpu\_per\_second](#input\_max\_ecpu\_per\_second) | The maximum ECPU per second of the Serverless Cache | `number` | `1000` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the application | `string` | `"value"` | no |
 | <a name="input_notification_topic_arn"></a> [notification\_topic\_arn](#input\_notification\_topic\_arn) | ARN of an SNS topic to send ElastiCache notifications | `string` | `""` | no |
 | <a name="input_num_node_groups"></a> [num\_node\_groups](#input\_num\_node\_groups) | Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. Required unless `global_replication_group_id` is set | `number` | `2` | no |
 | <a name="input_ok_actions"></a> [ok\_actions](#input\_ok\_actions) | The list of actions to execute when this alarm transitions into an OK state from any other state. | `list(string)` | `[]` | no |
-| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Excisting Parameter Group name | `string` | `""` | no |
+| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Existing Parameter Group name | `string` | `""` | no |
 | <a name="input_parameters"></a> [parameters](#input\_parameters) | A list of Redis parameters to apply. Note that parameters may differ from one Redis family to another | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_port"></a> [port](#input\_port) | Redis port | `number` | `6379` | no |
 | <a name="input_preferred_cache_cluster_azs"></a> [preferred\_cache\_cluster\_azs](#input\_preferred\_cache\_cluster\_azs) | List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is considered. The first item in the list will be the primary node. Ignored when updating | `list(string)` | <pre>[<br>  "ap-southeast-1a",<br>  "ap-southeast-1b"<br>]</pre> | no |
@@ -57,10 +68,13 @@ No modules.
 | <a name="input_replication_enabled"></a> [replication\_enabled](#input\_replication\_enabled) | Set to false to diable replication in redis cluster | `bool` | `false` | no |
 | <a name="input_replication_group_id"></a> [replication\_group\_id](#input\_replication\_group\_id) | ElastiCache replication\_group\_id | `string` | `""` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | List of  Security Group IDs to place the cluster into | `list(string)` | `[]` | no |
+| <a name="input_serverless_user_group_id"></a> [serverless\_user\_group\_id](#input\_serverless\_user\_group\_id) | The ID of the user group for Serverless Cache | `string` | `""` | no |
+| <a name="input_snapshot_arns_to_restore"></a> [snapshot\_arns\_to\_restore](#input\_snapshot\_arns\_to\_restore) | The ARN's of snapshot to restore Serverless Cache | `list(string)` | `[]` | no |
 | <a name="input_snapshot_retention_limit"></a> [snapshot\_retention\_limit](#input\_snapshot\_retention\_limit) | Number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of snapshot\_retention\_limit is set to zero (0), backups are turned off. Please note that setting a snapshot\_retention\_limit is not supported on cache.t1.micro cache nodes | `number` | `5` | no |
 | <a name="input_subnet_group_name"></a> [subnet\_group\_name](#input\_subnet\_group\_name) | Subnet group name for the ElastiCache instance | `string` | `""` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | AWS subnet ids | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (\_e.g.\_ map("BusinessUnit","ABC") | `map(string)` | `{}` | no |
+| <a name="input_use_serverless"></a> [use\_serverless](#input\_use\_serverless) | Use serverless ElastiCache service | `bool` | `false` | no |
 
 ## Outputs
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
 
   tags = var.tags
 
-  threshold = ceil(var.max_ecpu_per_second * var.alarm_cpu_threshold_percent / 100)
+  threshold = ceil(var.max_ecpu_per_second * var.alarm_ecpu_threshold_percent / 100)
 
   dimensions = {
     CacheClusterId = awscc_elasticache_serverless_cache.this[0].serverless_cache_name
@@ -92,11 +92,11 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   ]
 }
 
-resource "aws_cloudwatch_metric_alarm" "cache_serverless_memory" {
+resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name        = "${awscc_elasticache_serverless_cache.this[0].serverless_cache_name}-max-memory"
-  alarm_description = "Redis serverless max memory"
+  alarm_name        = "${awscc_elasticache_serverless_cache.this[0].serverless_cache_name}-data-storage"
+  alarm_description = "Redis serverless data storage"
 
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_memory" {
   period    = 60
   statistic = "Average"
 
-  threshold = (var.max_data_storage * 1000 * 1000 * 1000) - var.alarm_memory_threshold_bytes
+  threshold = ceil(var.max_data_storage * var.alarm_data_threshold_percent / 100)
 
   tags = var.tags
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_memory" {
   period    = 60
   statistic = "Average"
 
-  threshold = (var.max_data_storage * 1024 * 1024 * 1024) - var.alarm_memory_threshold_bytes
+  threshold = (var.max_data_storage * 1000 * 1000 * 1000) - var.alarm_memory_threshold_bytes
 
   tags = var.tags
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
   period    = 60
   statistic = "Average"
 
-  threshold = ceil(var.max_data_storage * var.alarm_data_threshold_percent / 100)
+  threshold = ceil((var.max_data_storage * 1000 * 1000 * 1000) * var.alarm_data_threshold_percent / 100)
 
   tags = var.tags
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
-  count = var.enabled ? local.num_nodes : 0
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
 
   alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-cpu-utilization"
   alarm_description = "Redis cluster CPU utilization"
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
-  count = var.enabled ? local.num_nodes : 0
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
 
   alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-freeable-memory"
   alarm_description = "Redis cluster freeable memory"

--- a/alarms.tf
+++ b/alarms.tf
@@ -140,7 +140,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
 
   threshold = 0
 
-  tags       = var.tags
+  tags = var.tags
   dimensions = {
     CacheClusterId = awscc_elasticache_serverless_cache.this[0].serverless_cache_name
   }

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_elasticache_subnet_group" "this" {
 }
 
 resource "aws_elasticache_replication_group" "this" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled && !var.use_serverless ? 1 : 0
 
   replication_group_id = var.replication_group_id == "" ? local.cluster_id : var.replication_group_id
   description          = "Redis Cluster Rep"
@@ -70,6 +70,38 @@ resource "aws_elasticache_replication_group" "this" {
 
   num_node_groups         = var.cluster_mode_enabled ? var.num_node_groups : null
   replicas_per_node_group = var.cluster_mode_enabled ? var.replicas_per_node_group : null
+
+  tags = var.tags
+}
+
+resource "aws_elasticache_serverless" "this" {
+  count = var.enabled && var.use_serverless ? 1 : 0
+
+  serverless_cache_name = var.name
+  description           = "NULL"
+
+  engine               = "redis"
+  major_engine_version = var.engine_version
+
+  cache_usage_limits {
+    data_storage {
+      maximum = 10
+      unit    = "GB"
+    }
+    ecpu_per_second {
+      maximum = 5
+    }
+  }
+
+  daily_snapshot_time = "09:00"
+  kms_key_id          = var.kms_key_id
+
+  security_group_ids = var.security_groups
+  subnet_ids         = var.subnets
+
+  snapshot_arns            = []
+  snapshot_retention_limit = 14
+  user_group_id            = "NULL"
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,7 @@ resource "awscc_elasticache_serverless_cache" "this" {
     }
   }
 
-  user_group_id = var.user_group_id
+  user_group_id = var.serverless_user_group_id
 
   final_snapshot_name = "${var.name}-elasticache-serverless-final-snapshot"
   kms_key_id          = var.kms_key_id

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 resource "aws_elasticache_parameter_group" "this" {
-  count = var.enabled && var.parameter_group_name == "" || var.parameter_group_name == null ? 1 : 0
+  count = var.enabled && var.parameter_group_name == "" && !var.use_serverless || var.parameter_group_name == null ? 1 : 0
 
   name   = var.name
   family = var.elasticache_parameter_group_family

--- a/main.tf
+++ b/main.tf
@@ -103,10 +103,10 @@ resource "awscc_elasticache_serverless_cache" "this" {
   snapshot_arns_to_restore = var.snapshot_arns_to_restore
   snapshot_retention_limit = var.snapshot_retention_limit
 
-  tags = toset([
+  tags = [
     for key, value in var.tags : {
       key   = key
       value = value
     }
-  ])
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -74,34 +74,37 @@ resource "aws_elasticache_replication_group" "this" {
   tags = var.tags
 }
 
-resource "aws_elasticache_serverless" "this" {
+resource "awscc_elasticache_serverless_cache" "this" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
   serverless_cache_name = var.name
-  description           = "NULL"
+  description           = "${var.name} ElastiCache Redis Serverless"
+  engine                = "redis"
+  major_engine_version  = var.engine_version
 
-  engine               = "redis"
-  major_engine_version = var.engine_version
-
-  cache_usage_limits {
-    data_storage {
-      maximum = 10
+  cache_usage_limits = {
+    data_storage = {
+      maximum = var.max_data_storage
       unit    = "GB"
     }
-    ecpu_per_second {
-      maximum = 5
+    ecpu_per_second = {
+      maximum = var.max_ecpu_per_second
     }
   }
 
-  daily_snapshot_time = "09:00"
+  final_snapshot_name = "${var.name}-elasticache-serverless-final-snapshot"
   kms_key_id          = var.kms_key_id
+  security_group_ids  = var.security_groups
+  subnet_ids          = var.subnets
 
-  security_group_ids = var.security_groups
-  subnet_ids         = var.subnets
+  daily_snapshot_time      = var.daily_snapshot_time
+  snapshot_arns_to_restore = var.snapshot_arns_to_restore
+  snapshot_retention_limit = var.snapshot_retention_limit
 
-  snapshot_arns            = []
-  snapshot_retention_limit = 14
-  user_group_id            = "NULL"
-
-  tags = var.tags
+  tags = toset([
+    for key, value in var.tags : {
+      key   = key
+      value = value
+    }
+  ])
 }

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,8 @@ resource "awscc_elasticache_serverless_cache" "this" {
     }
   }
 
+  user_group_id = var.user_group_id
+
   final_snapshot_name = "${var.name}-elasticache-serverless-final-snapshot"
   kms_key_id          = var.kms_key_id
   security_group_ids  = var.security_groups

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "endpoint" {
   description = "Redis primary or configuration endpoint, whichever is appropriate for the given cluster mode"
-  value       = var.use_serverless ? try(aws_elasticache_serverless.this[0].address, null) : try(aws_elasticache_replication_group.this[0].primary_endpoint_address, null)
+  value       = var.use_serverless ? try(awscc_elasticache_serverless_cache.this[0].endpoint.address, null) : try(aws_elasticache_replication_group.this[0].primary_endpoint_address, null)
 }
 
 output "reader_endpoint_address" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "endpoint" {
   description = "Redis primary or configuration endpoint, whichever is appropriate for the given cluster mode"
-  value       = try(aws_elasticache_replication_group.this[0].primary_endpoint_address, null)
+  value       = var.use_serverless ? try(aws_elasticache_serverless.this[0].address, null) : try(aws_elasticache_replication_group.this[0].primary_endpoint_address, null)
 }
 
 output "reader_endpoint_address" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "member_clusters" {
 
 output "arn" {
   description = "Elasticache Replication Group ARN"
-  value       = try(aws_elasticache_replication_group.this[0].arn, null)
+  value       = var.use_serverless ? try(awscc_elasticache_serverless_cache.this[0].arn, null) : try(aws_elasticache_replication_group.this[0].arn, null)
 }
 
 output "cluster_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,10 +64,22 @@ variable "alarm_cpu_threshold_percent" {
   default     = 75
 }
 
+variable "alarm_ecpu_threshold_percent" {
+  description = "ECPU threshold alarm level for elasticache serverless"
+  type        = number
+  default     = 75
+}
+
 variable "alarm_memory_threshold_bytes" {
   description = "Alarm memory threshold bytes"
   type        = number
   default     = 10000000 # 10MB
+}
+
+variable "alarm_data_threshold_percent" {
+  description = "Data threshold alarm level for elasticache serverless"
+  type        = number
+  default     = 75
 }
 
 variable "notification_topic_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -199,7 +199,7 @@ variable "use_serverless" {
 
 variable "max_data_storage" {
   type        = number
-  description = "The maximun cached data capacity of the Serverless Cache"
+  description = "The maximun cached data capacity of the Serverless Cache in GB"
   default     = 10
 
   validation {
@@ -222,7 +222,7 @@ variable "max_ecpu_per_second" {
 variable "daily_snapshot_time" {
   type        = string
   description = "The daily time range (in UTC) during which the service takes automatic snapshot of the Serverless Cache"
-  default     = "09:00"
+  default     = "18:00"
 }
 
 variable "snapshot_arns_to_restore" {
@@ -231,8 +231,8 @@ variable "snapshot_arns_to_restore" {
   default     = []
 }
 
-variable "user_group_id" {
+variable "serverless_user_group_id" {
   type        = string
-  description = "The ID of the user group"
+  description = "The ID of the user group for Serverless Cache"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -155,7 +155,7 @@ variable "preferred_cache_cluster_azs" {
 }
 
 variable "parameter_group_name" {
-  description = "Excisting Parameter Group name"
+  description = "Existing Parameter Group name"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -190,8 +190,49 @@ variable "replicas_per_node_group" {
   default     = 1
 }
 
+# ElastiCache Serverless
 variable "use_serverless" {
   description = "Use serverless ElastiCache service"
   type        = bool
   default     = false
+}
+
+variable "max_data_storage" {
+  type        = number
+  description = "The maximun cached data capacity of the Serverless Cache"
+  default     = 10
+
+  validation {
+    condition     = var.max_data_storage >= 1 && var.max_data_storage <= 5000
+    error_message = "The max_data_storage in GB value must be between 1 and 5,000."
+  }
+}
+
+variable "max_ecpu_per_second" {
+  type        = number
+  description = "The maximum ECPU per second of the Serverless Cache"
+  default     = 1000
+
+  validation {
+    condition     = var.max_ecpu_per_second >= 1000 && var.max_ecpu_per_second <= 15000000
+    error_message = "The max_ecpu_per_second value must be between 1,000 and 15,000,000."
+  }
+}
+
+variable "daily_snapshot_time" {
+  type        = string
+  description = "The daily time range (in UTC) during which the service takes automatic snapshot of the Serverless Cache"
+  default     = "09:00"
+}
+
+variable "snapshot_arns_to_restore" {
+  type        = list(string)
+  description = "The ARN's of snapshot to restore Serverless Cache"
+  default     = []
+}
+
+variable "user_group_id" {
+  type        = string
+  description = "The ID of the user group"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -189,3 +189,9 @@ variable "replicas_per_node_group" {
   type        = number
   default     = 1
 }
+
+variable "use_serverless" {
+  description = "Use serverless ElastiCache service"
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0"
     }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.67.0"
+    }
   }
 }


### PR DESCRIPTION
# Description
Add support for elasticache serverless with awscc resource => `awscc_elasticache_serverless`

Changes
- Add `awscc_elasticache_serverless`
- Alarms for elasticache serverless (max ecpu, max memory, and throttled commands)
- Additional conditional to ensure that parameter group, replication group gets created only for elasticache replication group
- Output correct endpoint, arn for elasticache serverless
- Additional variable to support elasticache serverless

There will be an updated to this module for aws provider elasticache serverless resource when it's made available. https://github.com/hashicorp/terraform-provider-aws/pull/34951

