### PR TITLE
Add support for user_group_id to elasticache replication group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,8 @@ resource "aws_elasticache_replication_group" "this" {
   num_node_groups         = var.cluster_mode_enabled ? var.num_node_groups : null
   replicas_per_node_group = var.cluster_mode_enabled ? var.replicas_per_node_group : null
 
+  user_group_ids = [var.user_group_id]
+
   tags = var.tags
 }
 
@@ -92,7 +94,7 @@ resource "awscc_elasticache_serverless_cache" "this" {
     }
   }
 
-  user_group_id = var.serverless_user_group_id
+  user_group_id = var.user_group_id
 
   final_snapshot_name = "${var.name}-elasticache-serverless-final-snapshot"
   kms_key_id          = var.kms_key_id

--- a/variables.tf
+++ b/variables.tf
@@ -243,8 +243,8 @@ variable "snapshot_arns_to_restore" {
   default     = []
 }
 
-variable "serverless_user_group_id" {
+variable "user_group_id" {
   type        = string
-  description = "The ID of the user group for Serverless Cache"
+  description = "The ID of the user group Elasticache"
   default     = ""
 }


### PR DESCRIPTION
Allow configuration of `user_group_ids` for elasticache replication group resource.

Also renamed `serverless_user_group_id` to `user_group_id` for ease of use between replication group and serverless setup.