### PR TITLE
feat(alarms): consolidate and improve ElastiCache CloudWatch alarms

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -1,175 +1,175 @@
-resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
-  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+locals {
+  member_clusters       = var.enabled && !var.use_serverless ? toset(aws_elasticache_replication_group.this[0].member_clusters) : toset([])
+  serverless_cache_name = var.enabled && var.use_serverless ? aws_elasticache_serverless_cache.this[0].name : ""
 
-  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-cpu-utilization"
+  # Shared alarm defaults — change here to apply consistently across all non-serverless alarms
+  alarm_namespace           = "AWS/ElastiCache"
+  alarm_period              = 60
+  alarm_treat_missing_data  = "notBreaching"
+  alarm_evaluation_periods  = 5
+  alarm_datapoints_to_alarm = 5
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
+  for_each = local.member_clusters
+
+  alarm_name          = "${each.key}-cpu-utilization"
   alarm_description   = "Redis host CPU utilization"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 5
-  datapoints_to_alarm = 5
+  evaluation_periods  = local.alarm_evaluation_periods
+  datapoints_to_alarm = local.alarm_datapoints_to_alarm
   threshold           = var.alarm_cpu_threshold_percent
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "CPUUtilization"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Average"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = local.alarm_treat_missing_data
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+    CacheClusterId = each.key
   }
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_engine_cpu" {
-  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+  for_each = local.member_clusters
 
-  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-engine-cpu-utilization"
+  alarm_name          = "${each.key}-engine-cpu-utilization"
   alarm_description   = "Redis engine CPU utilization"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 5
-  datapoints_to_alarm = 5
+  evaluation_periods  = local.alarm_evaluation_periods
+  datapoints_to_alarm = local.alarm_datapoints_to_alarm
   threshold           = var.alarm_engine_cpu_threshold_percent
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "EngineCPUUtilization"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Average"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = local.alarm_treat_missing_data
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+    CacheClusterId = each.key
   }
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
-  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+  for_each = local.member_clusters
 
-  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-freeable-memory"
+  alarm_name          = "${each.key}-freeable-memory"
   alarm_description   = "Redis host freeable memory drops below threshold"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = 5
-  datapoints_to_alarm = 5
+  evaluation_periods  = local.alarm_evaluation_periods
+  datapoints_to_alarm = local.alarm_datapoints_to_alarm
   threshold           = var.alarm_memory_threshold_bytes
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "FreeableMemory"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Average"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = local.alarm_treat_missing_data
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+    CacheClusterId = each.key
   }
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_evictions" {
-  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+  for_each = local.member_clusters
 
-  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-evictions"
+  alarm_name          = "${each.key}-evictions"
   alarm_description   = "Redis evictions due to maxmemory limit"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   datapoints_to_alarm = 1
   threshold           = var.alarm_evictions_threshold
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "Evictions"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Sum"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = local.alarm_treat_missing_data
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+    CacheClusterId = each.key
   }
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_curr_connections" {
-  count = var.enabled && !var.use_serverless && var.alarm_curr_connections_threshold != null ? local.num_nodes : 0
+  for_each = var.alarm_curr_connections_threshold != null ? local.member_clusters : toset([])
 
-  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-curr-connections"
+  alarm_name          = "${each.key}-curr-connections"
   alarm_description   = "Redis client connections"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 5
-  datapoints_to_alarm = 5
+  evaluation_periods  = local.alarm_evaluation_periods
+  datapoints_to_alarm = local.alarm_datapoints_to_alarm
   threshold           = var.alarm_curr_connections_threshold
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "CurrConnections"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Average"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = local.alarm_treat_missing_data
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+    CacheClusterId = each.key
   }
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_replication_lag" {
-  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+  for_each = local.member_clusters
 
-  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-replication-lag"
+  alarm_name          = "${each.key}-replication-lag"
   alarm_description   = "Redis replication lag"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 5
-  datapoints_to_alarm = 5
+  evaluation_periods  = local.alarm_evaluation_periods
+  datapoints_to_alarm = local.alarm_datapoints_to_alarm
   threshold           = var.alarm_replication_lag_threshold_seconds
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "ReplicationLag"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Maximum"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = local.alarm_treat_missing_data
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+    CacheClusterId = each.key
   }
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_replication_group.this]
 }
 
 # ElastiCache Serverless
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name          = "${aws_elasticache_serverless_cache.this[0].name}-ecpu-utilization"
+  alarm_name          = "${local.serverless_cache_name}-ecpu-utilization"
   alarm_description   = "Redis serverless ECPU utilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   threshold           = ceil(var.max_ecpu_per_second * var.alarm_ecpu_threshold_percent / 100)
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "ElastiCacheProcessingUnits"
   period              = 300
   statistic           = "Average"
@@ -177,7 +177,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = aws_elasticache_serverless_cache.this[0].name
+    CacheClusterId = local.serverless_cache_name
   }
 
   alarm_actions = var.alarm_actions
@@ -187,20 +187,20 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name          = "${aws_elasticache_serverless_cache.this[0].name}-data-storage"
+  alarm_name          = "${local.serverless_cache_name}-data-storage"
   alarm_description   = "Redis serverless data storage"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   threshold           = ceil((var.max_data_storage * 1000 * 1000 * 1000) * var.alarm_data_threshold_percent / 100)
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "BytesUsedForCache"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Average"
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = aws_elasticache_serverless_cache.this[0].name
+    CacheClusterId = local.serverless_cache_name
   }
 
   alarm_actions = var.alarm_actions
@@ -210,20 +210,20 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name          = "${aws_elasticache_serverless_cache.this[0].name}-throttled-commands"
+  alarm_name          = "${local.serverless_cache_name}-throttled-commands"
   alarm_description   = "Redis serverless throttled commands"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   threshold           = 0
-  namespace           = "AWS/ElastiCache"
+  namespace           = local.alarm_namespace
   metric_name         = "ThrottledCmds"
-  period              = 60
+  period              = local.alarm_period
   statistic           = "Average"
 
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = aws_elasticache_serverless_cache.this[0].name
+    CacheClusterId = local.serverless_cache_name
   }
 
   alarm_actions = var.alarm_actions

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,6 +1,6 @@
 locals {
-  member_clusters       = var.enabled && !var.use_serverless ? toset(aws_elasticache_replication_group.this[0].member_clusters) : toset([])
-  serverless_cache_name = var.enabled && var.use_serverless ? aws_elasticache_serverless_cache.this[0].name : ""
+  cluster_ids     = var.enabled && !var.use_serverless ? toset(aws_elasticache_replication_group.this[0].member_clusters) : toset([])
+  serverless_name = var.enabled && var.use_serverless ? aws_elasticache_serverless_cache.this[0].name : ""
 
   # Shared alarm defaults — change here to apply consistently across all non-serverless alarms
   alarm_namespace           = "AWS/ElastiCache"
@@ -10,33 +10,9 @@ locals {
   alarm_datapoints_to_alarm = 5
 }
 
-resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
-  for_each = local.member_clusters
-
-  alarm_name          = "${each.key}-cpu-utilization"
-  alarm_description   = "Redis host CPU utilization"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = local.alarm_evaluation_periods
-  datapoints_to_alarm = local.alarm_datapoints_to_alarm
-  threshold           = var.alarm_cpu_threshold_percent
-  namespace           = local.alarm_namespace
-  metric_name         = "CPUUtilization"
-  period              = local.alarm_period
-  statistic           = "Average"
-  treat_missing_data  = local.alarm_treat_missing_data
-
-  tags = var.tags
-
-  dimensions = {
-    CacheClusterId = each.key
-  }
-
-  alarm_actions = var.alarm_actions
-  ok_actions    = var.ok_actions
-}
 
 resource "aws_cloudwatch_metric_alarm" "cache_engine_cpu" {
-  for_each = local.member_clusters
+  for_each = local.cluster_ids
 
   alarm_name          = "${each.key}-engine-cpu-utilization"
   alarm_description   = "Redis engine CPU utilization"
@@ -61,7 +37,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_engine_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
-  for_each = local.member_clusters
+  for_each = local.cluster_ids
 
   alarm_name          = "${each.key}-freeable-memory"
   alarm_description   = "Redis host freeable memory drops below threshold"
@@ -86,7 +62,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_evictions" {
-  for_each = local.member_clusters
+  for_each = local.cluster_ids
 
   alarm_name          = "${each.key}-evictions"
   alarm_description   = "Redis evictions due to maxmemory limit"
@@ -111,7 +87,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_evictions" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_curr_connections" {
-  for_each = var.alarm_curr_connections_threshold != null ? local.member_clusters : toset([])
+  for_each = var.alarm_curr_connections_threshold != null ? local.cluster_ids : toset([])
 
   alarm_name          = "${each.key}-curr-connections"
   alarm_description   = "Redis client connections"
@@ -136,7 +112,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_curr_connections" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_replication_lag" {
-  for_each = local.member_clusters
+  for_each = var.replication_enabled ? local.cluster_ids : toset([])
 
   alarm_name          = "${each.key}-replication-lag"
   alarm_description   = "Redis replication lag"
@@ -164,7 +140,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_replication_lag" {
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name          = "${local.serverless_cache_name}-ecpu-utilization"
+  alarm_name          = "${local.serverless_name}-ecpu-utilization"
   alarm_description   = "Redis serverless ECPU utilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -177,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = local.serverless_cache_name
+    CacheClusterId = local.serverless_name
   }
 
   alarm_actions = var.alarm_actions
@@ -187,7 +163,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name          = "${local.serverless_cache_name}-data-storage"
+  alarm_name          = "${local.serverless_name}-data-storage"
   alarm_description   = "Redis serverless data storage"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -200,7 +176,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = local.serverless_cache_name
+    CacheClusterId = local.serverless_name
   }
 
   alarm_actions = var.alarm_actions
@@ -210,7 +186,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name          = "${local.serverless_cache_name}-throttled-commands"
+  alarm_name          = "${local.serverless_name}-throttled-commands"
   alarm_description   = "Redis serverless throttled commands"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -223,7 +199,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
   tags = var.tags
 
   dimensions = {
-    CacheClusterId = local.serverless_cache_name
+    CacheClusterId = local.serverless_name
   }
 
   alarm_actions = var.alarm_actions

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,21 +1,19 @@
 resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
   count = var.enabled && !var.use_serverless ? local.num_nodes : 0
 
-  alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-cpu-utilization"
-  alarm_description = "Redis cluster CPU utilization"
-
+  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-cpu-utilization"
+  alarm_description   = "Redis host CPU utilization"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-
-  metric_name = "CPUUtilization"
-  namespace   = "AWS/ElastiCache"
-
-  period    = 300
-  statistic = "Average"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
+  threshold           = var.alarm_cpu_threshold_percent
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "CPUUtilization"
+  period              = 60
+  statistic           = "Average"
+  treat_missing_data  = "notBreaching"
 
   tags = var.tags
-
-  threshold = var.alarm_cpu_threshold_percent
 
   dimensions = {
     CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
@@ -24,27 +22,50 @@ resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
 
-  depends_on = [
-    aws_elasticache_replication_group.this
-  ]
+  depends_on = [aws_elasticache_replication_group.this]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_engine_cpu" {
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+
+  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-engine-cpu-utilization"
+  alarm_description   = "Redis engine CPU utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
+  threshold           = var.alarm_engine_cpu_threshold_percent
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "EngineCPUUtilization"
+  period              = 60
+  statistic           = "Average"
+  treat_missing_data  = "notBreaching"
+
+  tags = var.tags
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
   count = var.enabled && !var.use_serverless ? local.num_nodes : 0
 
-  alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-freeable-memory"
-  alarm_description = "Redis cluster freeable memory"
-
+  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-freeable-memory"
+  alarm_description   = "Redis host freeable memory drops below threshold"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = 1
-
-  metric_name = "FreeableMemory"
-  namespace   = "AWS/ElastiCache"
-
-  period    = 60
-  statistic = "Average"
-
-  threshold = var.alarm_memory_threshold_bytes
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
+  threshold           = var.alarm_memory_threshold_bytes
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "FreeableMemory"
+  period              = 60
+  statistic           = "Average"
+  treat_missing_data  = "notBreaching"
 
   tags = var.tags
 
@@ -55,30 +76,105 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
 
-  depends_on = [
-    aws_elasticache_replication_group.this
-  ]
+  depends_on = [aws_elasticache_replication_group.this]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_evictions" {
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+
+  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-evictions"
+  alarm_description   = "Redis evictions due to maxmemory limit"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = var.alarm_evictions_threshold
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "Evictions"
+  period              = 60
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+
+  tags = var.tags
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [aws_elasticache_replication_group.this]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_curr_connections" {
+  count = var.enabled && !var.use_serverless && var.alarm_curr_connections_threshold != null ? local.num_nodes : 0
+
+  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-curr-connections"
+  alarm_description   = "Redis client connections"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
+  threshold           = var.alarm_curr_connections_threshold
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "CurrConnections"
+  period              = 60
+  statistic           = "Average"
+  treat_missing_data  = "notBreaching"
+
+  tags = var.tags
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [aws_elasticache_replication_group.this]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_replication_lag" {
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+
+  alarm_name          = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-replication-lag"
+  alarm_description   = "Redis replication lag"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
+  threshold           = var.alarm_replication_lag_threshold_seconds
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "ReplicationLag"
+  period              = 60
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+
+  tags = var.tags
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [aws_elasticache_replication_group.this]
 }
 
 # ElastiCache Serverless
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name        = "${aws_elasticache_serverless_cache.this[0].name}-ecpu-utilization"
-  alarm_description = "Redis serverless ECPU utilization"
-
+  alarm_name          = "${aws_elasticache_serverless_cache.this[0].name}-ecpu-utilization"
+  alarm_description   = "Redis serverless ECPU utilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
-
-  metric_name = "ElastiCacheProcessingUnits"
-  namespace   = "AWS/ElastiCache"
-
-  period    = 300
-  statistic = "Average"
+  threshold           = ceil(var.max_ecpu_per_second * var.alarm_ecpu_threshold_percent / 100)
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "ElastiCacheProcessingUnits"
+  period              = 300
+  statistic           = "Average"
 
   tags = var.tags
-
-  threshold = ceil(var.max_ecpu_per_second * var.alarm_ecpu_threshold_percent / 100)
 
   dimensions = {
     CacheClusterId = aws_elasticache_serverless_cache.this[0].name
@@ -87,27 +183,21 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
 
-  depends_on = [
-    aws_elasticache_serverless_cache.this
-  ]
+  depends_on = [aws_elasticache_serverless_cache.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name        = "${aws_elasticache_serverless_cache.this[0].name}-data-storage"
-  alarm_description = "Redis serverless data storage"
-
+  alarm_name          = "${aws_elasticache_serverless_cache.this[0].name}-data-storage"
+  alarm_description   = "Redis serverless data storage"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
-
-  metric_name = "BytesUsedForCache"
-  namespace   = "AWS/ElastiCache"
-
-  period    = 60
-  statistic = "Average"
-
-  threshold = ceil((var.max_data_storage * 1000 * 1000 * 1000) * var.alarm_data_threshold_percent / 100)
+  threshold           = ceil((var.max_data_storage * 1000 * 1000 * 1000) * var.alarm_data_threshold_percent / 100)
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "BytesUsedForCache"
+  period              = 60
+  statistic           = "Average"
 
   tags = var.tags
 
@@ -118,29 +208,24 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
 
-  depends_on = [
-    aws_elasticache_replication_group.this
-  ]
+  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
   count = var.enabled && var.use_serverless ? 1 : 0
 
-  alarm_name        = "${aws_elasticache_serverless_cache.this[0].name}-throttled-commands"
-  alarm_description = "Redis serverless throttled commands"
-
+  alarm_name          = "${aws_elasticache_serverless_cache.this[0].name}-throttled-commands"
+  alarm_description   = "Redis serverless throttled commands"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
-
-  metric_name = "ThrottledCmds"
-  namespace   = "AWS/ElastiCache"
-
-  period    = 60
-  statistic = "Average"
-
-  threshold = 0
+  threshold           = 0
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "ThrottledCmds"
+  period              = 60
+  statistic           = "Average"
 
   tags = var.tags
+
   dimensions = {
     CacheClusterId = aws_elasticache_serverless_cache.this[0].name
   }
@@ -148,7 +233,5 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
 
-  depends_on = [
-    aws_elasticache_serverless_cache.this
-  ]
+  depends_on = [aws_elasticache_serverless_cache.this]
 }

--- a/alarms.tf
+++ b/alarms.tf
@@ -182,8 +182,6 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_serverless_cache.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
@@ -207,8 +205,6 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_data" {
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_replication_group.this]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
@@ -232,6 +228,4 @@ resource "aws_cloudwatch_metric_alarm" "cache_serverless_throttled_commands" {
 
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
-
-  depends_on = [aws_elasticache_serverless_cache.this]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,7 @@ variable "alarm_evictions_threshold" {
 variable "alarm_curr_connections_threshold" {
   description = "CurrConnections alarm threshold. Leave null to disable; the right value depends on the node type."
   type        = number
+  nullable    = true
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -69,11 +69,6 @@ variable "engine_version" {
   default     = "7.0"
 }
 
-variable "alarm_cpu_threshold_percent" {
-  description = "CPU threshold alarm level"
-  type        = number
-  default     = 75
-}
 
 variable "alarm_ecpu_threshold_percent" {
   description = "ECPU threshold alarm level for elasticache serverless"
@@ -84,7 +79,7 @@ variable "alarm_ecpu_threshold_percent" {
 variable "alarm_memory_threshold_bytes" {
   description = "Alarm memory threshold bytes"
   type        = number
-  default     = 10000000 # 10MB
+  default     = 104857600 # 100MB
 }
 
 variable "alarm_data_threshold_percent" {

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,30 @@ variable "ok_actions" {
   default     = []
 }
 
+variable "alarm_engine_cpu_threshold_percent" {
+  description = "EngineCPUUtilization alarm threshold percent."
+  type        = number
+  default     = 80
+}
+
+variable "alarm_evictions_threshold" {
+  description = "Evictions alarm threshold. Set to 0 to alert on any eviction."
+  type        = number
+  default     = 0
+}
+
+variable "alarm_curr_connections_threshold" {
+  description = "CurrConnections alarm threshold. Leave null to disable; the right value depends on the node type."
+  type        = number
+  default     = null
+}
+
+variable "alarm_replication_lag_threshold_seconds" {
+  description = "ReplicationLag alarm threshold in seconds."
+  type        = number
+  default     = 5
+}
+
 variable "apply_immediately" {
   description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
   type        = bool


### PR DESCRIPTION
## Summary

Added 4 new alarms for non-serverless clusters:

- cache_engine_cpu — EngineCPUUtilization, threshold configurable via alarm_engine_cpu_threshold_percent (default 80%)
- cache_evictions — Evictions sum, fires on any eviction by default (alarm_evictions_threshold = 0)
- cache_curr_connections — CurrConnections, disabled by default (alarm_curr_connections_threshold = null); right value is node-type dependent
- cache_replication_lag — ReplicationLag maximum, threshold configurable via alarm_replication_lag_threshold_seconds (default 5s)