### PR TITLE
feat(alarms): consolidate and improve ElastiCache CloudWatch alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 
@@ -21,7 +21,11 @@ No modules.
 | Name | Type |
 | ---- | ---- |
 | [aws_cloudwatch_metric_alarm.cache_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cache_curr_connections](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cache_engine_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cache_evictions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.cache_memory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cache_replication_lag](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.cache_serverless_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.cache_serverless_ecpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.cache_serverless_throttled_commands](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -36,9 +40,13 @@ No modules.
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | The list of actions to execute when this alarm transitions into an ALARM state from any other state. | `list(string)` | `[]` | no |
 | <a name="input_alarm_cpu_threshold_percent"></a> [alarm\_cpu\_threshold\_percent](#input\_alarm\_cpu\_threshold\_percent) | CPU threshold alarm level | `number` | `75` | no |
+| <a name="input_alarm_curr_connections_threshold"></a> [alarm\_curr\_connections\_threshold](#input\_alarm\_curr\_connections\_threshold) | Current connections threshold alarm level. Adjust to suit the connection limit of the chosen instance type. | `number` | `20000` | no |
 | <a name="input_alarm_data_threshold_percent"></a> [alarm\_data\_threshold\_percent](#input\_alarm\_data\_threshold\_percent) | Data threshold alarm level for elasticache serverless | `number` | `75` | no |
 | <a name="input_alarm_ecpu_threshold_percent"></a> [alarm\_ecpu\_threshold\_percent](#input\_alarm\_ecpu\_threshold\_percent) | ECPU threshold alarm level for elasticache serverless | `number` | `75` | no |
+| <a name="input_alarm_engine_cpu_threshold_percent"></a> [alarm\_engine\_cpu\_threshold\_percent](#input\_alarm\_engine\_cpu\_threshold\_percent) | Engine CPU threshold alarm level | `number` | `90` | no |
+| <a name="input_alarm_evictions_threshold"></a> [alarm\_evictions\_threshold](#input\_alarm\_evictions\_threshold) | Evictions threshold alarm level | `number` | `0` | no |
 | <a name="input_alarm_memory_threshold_bytes"></a> [alarm\_memory\_threshold\_bytes](#input\_alarm\_memory\_threshold\_bytes) | Alarm memory threshold bytes | `number` | `10000000` | no |
+| <a name="input_alarm_replication_lag_threshold_seconds"></a> [alarm\_replication\_lag\_threshold\_seconds](#input\_alarm\_replication\_lag\_threshold\_seconds) | Replication lag threshold alarm level in seconds | `number` | `5` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `true` | no |
 | <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Whether to enable encryption at rest | `string` | `true` | no |
 | <a name="input_auth_token"></a> [auth\_token](#input\_auth\_token) | Password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true` | `string` | `null` | no |

--- a/alarms.tf
+++ b/alarms.tf
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_engine_cpu" {
 
   tags = var.tags
 
-  threshold = var.alarm_ecpu_threshold_percent
+  threshold = var.alarm_engine_cpu_threshold_percent
 
   dimensions = {
     CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]

--- a/alarms.tf
+++ b/alarms.tf
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_engine_cpu" {
 
   tags = var.tags
 
-  threshold = var.alarm_engine_cpu_threshold_percent
+  threshold = var.alarm_ecpu_threshold_percent
 
   dimensions = {
     CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
@@ -143,6 +143,37 @@ resource "aws_cloudwatch_metric_alarm" "cache_replication_lag" {
 
   # Primary nodes do not emit this metric, so missing data should not alarm.
   treat_missing_data = "notBreaching"
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [
+    aws_elasticache_replication_group.this
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_curr_connections" {
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+
+  alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-curr-connections"
+  alarm_description = "Redis cluster current connections"
+
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+
+  metric_name = "CurrConnections"
+  namespace   = "AWS/ElastiCache"
+
+  period    = 60
+  statistic = "Average"
+
+  tags = var.tags
+
+  threshold = var.alarm_curr_connections_threshold
 
   dimensions = {
     CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]

--- a/alarms.tf
+++ b/alarms.tf
@@ -157,7 +157,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_replication_lag" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_curr_connections" {
-  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+  count = var.enabled && !var.use_serverless && var.alarm_curr_connections_threshold != null ? local.num_nodes : 0
 
   alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-curr-connections"
   alarm_description = "Redis cluster current connections"

--- a/alarms.tf
+++ b/alarms.tf
@@ -60,6 +60,102 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
   ]
 }
 
+resource "aws_cloudwatch_metric_alarm" "cache_engine_cpu" {
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+
+  alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-engine-cpu-utilization"
+  alarm_description = "Redis cluster engine CPU utilization"
+
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+
+  metric_name = "EngineCPUUtilization"
+  namespace   = "AWS/ElastiCache"
+
+  period    = 300
+  statistic = "Average"
+
+  tags = var.tags
+
+  threshold = var.alarm_engine_cpu_threshold_percent
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [
+    aws_elasticache_replication_group.this
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_evictions" {
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+
+  alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-evictions"
+  alarm_description = "Redis cluster evictions"
+
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+
+  metric_name = "Evictions"
+  namespace   = "AWS/ElastiCache"
+
+  period    = 60
+  statistic = "Sum"
+
+  tags = var.tags
+
+  threshold = var.alarm_evictions_threshold
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [
+    aws_elasticache_replication_group.this
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_replication_lag" {
+  count = var.enabled && !var.use_serverless ? local.num_nodes : 0
+
+  alarm_name        = "${tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]}-replication-lag"
+  alarm_description = "Redis cluster replication lag"
+
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+
+  metric_name = "ReplicationLag"
+  namespace   = "AWS/ElastiCache"
+
+  period    = 60
+  statistic = "Average"
+
+  tags = var.tags
+
+  threshold = var.alarm_replication_lag_threshold_seconds
+
+  # Primary nodes do not emit this metric, so missing data should not alarm.
+  treat_missing_data = "notBreaching"
+
+  dimensions = {
+    CacheClusterId = tolist(aws_elasticache_replication_group.this[0].member_clusters)[count.index]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  depends_on = [
+    aws_elasticache_replication_group.this
+  ]
+}
+
 # ElastiCache Serverless
 resource "aws_cloudwatch_metric_alarm" "cache_serverless_ecpu" {
   count = var.enabled && var.use_serverless ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,24 @@ variable "alarm_data_threshold_percent" {
   default     = 75
 }
 
+variable "alarm_engine_cpu_threshold_percent" {
+  description = "Engine CPU threshold alarm level"
+  type        = number
+  default     = 90
+}
+
+variable "alarm_evictions_threshold" {
+  description = "Evictions threshold alarm level"
+  type        = number
+  default     = 0
+}
+
+variable "alarm_replication_lag_threshold_seconds" {
+  description = "Replication lag threshold alarm level in seconds"
+  type        = number
+  default     = 5
+}
+
 variable "notification_topic_arn" {
   description = "ARN of an SNS topic to send ElastiCache notifications"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "alarm_replication_lag_threshold_seconds" {
 variable "alarm_curr_connections_threshold" {
   description = "Current connections threshold alarm level. Adjust to suit the connection limit of the chosen instance type."
   type        = number
-  default     = 20000
+  default     = null
 }
 
 variable "notification_topic_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "alarm_data_threshold_percent" {
 variable "alarm_engine_cpu_threshold_percent" {
   description = "Engine CPU threshold alarm level"
   type        = number
-  default     = 90
+  default     = 80
 }
 
 variable "alarm_evictions_threshold" {
@@ -109,6 +109,12 @@ variable "alarm_replication_lag_threshold_seconds" {
   description = "Replication lag threshold alarm level in seconds"
   type        = number
   default     = 5
+}
+
+variable "alarm_curr_connections_threshold" {
+  description = "Current connections threshold alarm level. Adjust to suit the connection limit of the chosen instance type."
+  type        = number
+  default     = 20000
 }
 
 variable "notification_topic_arn" {


### PR DESCRIPTION
Added 4 new alarms for non-serverless clusters:

- cache_engine_cpu — EngineCPUUtilization, threshold configurable via alarm_engine_cpu_threshold_percent (default 80%)
- cache_evictions — Evictions sum, fires on any eviction by default (alarm_evictions_threshold = 0)
- cache_curr_connections — CurrConnections, disabled by default (alarm_curr_connections_threshold = null); right value is node-type dependent
- cache_replication_lag — ReplicationLag maximum, threshold configurable via alarm_replication_lag_threshold_seconds (default 5s)